### PR TITLE
Simplify FCFileInfo with C++17.

### DIFF
--- a/src/FCFileInfo.hpp
+++ b/src/FCFileInfo.hpp
@@ -81,8 +81,8 @@ class FCFileInfo
     std::string filePath;
     std::string fileAcls;
     std::string fileCaps;
-    std::hash<std ::string>::result_type filePathHash;
-    std::hash<std ::string>::result_type fileCrcHash;
+    std::size_t filePathHash;
+    std::size_t fileCrcHash;
 
     //implementation of reflect solution to iterate over class t_embers
     auto reflect() const;


### PR DESCRIPTION
Few simplifications in FCFileInfo:

- structure bindings instead of std :: tie - initialise variables with proper values, helps with keeping them const, less code to read
- std :: apply instead of handwritten code - simpler,
- since C++17 result_type in std :: hash is deprecated.