### PR TITLE
Add SYSTEM property for all submodules to avoid unneded warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,6 @@ target_compile_features(project_options INTERFACE cxx_std_17)
 include(cmake/StaticAnalyzers.cmake)
 
 include_directories(${CMAKE_SOURCE_DIR})
-
-add_subdirectory(submodules)
+add_subdirectory(submodules EXCLUDE_FROM_ALL SYSTEM)
 add_subdirectory(src)
 add_subdirectory(tests)

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,6 @@ RUN apt-get update && \
 	wget \
 	gcc-${GCC_VERSION} \
 	g++-${GCC_VERSION} \
-	cmake \
     clang \
 #    clang-doc \
     clang-format \
@@ -42,6 +41,11 @@ RUN apt-get update && \
 	pip3 install pyyaml \
 && mkdir /opt/project
 
+# Install cmake v3.25 for SYSTEM property
+# https://cmake.org/cmake/help/latest/prop_dir/SYSTEM.html
+RUN wget -O /tmp/cmake.sh https://github.com/Kitware/CMake/releases/download/v3.25.0-rc2/cmake-3.25.0-rc2-linux-x86_64.sh \
+ && bash /tmp/cmake.sh --skip-license --prefix=/usr --exclude-subdir \
+ && rm /tmp/cmake.sh
 WORKDIR /opt/project
 
 CMD echo ${PWD} && \

--- a/submodules/CMakeLists.txt
+++ b/submodules/CMakeLists.txt
@@ -8,8 +8,7 @@ set(SQLITECPP_RUN_CPPCHECK
     OFF
     CACHE BOOL "Do not run cppcheck for sqlitecpp")
 add_subdirectory(SQLiteCpp)
-
-add_subdirectory(fmt EXCLUDE_FROM_ALL)
+add_subdirectory(fmt)
 
 set(SPDLOG_FMT_EXTERNAL_HO ON)
-add_subdirectory(spdlog EXCLUDE_FROM_ALL)
+add_subdirectory(spdlog)


### PR DESCRIPTION
Before:

 > -I/opt/project/submodules/fmt/include

After:

 > -isystem /opt/project/submodules/fmt/include
