### PR TITLE
Remove the top-level include directory. Fix includes.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,8 +16,6 @@ target_compile_features(project_options INTERFACE cxx_std_17)
 # allow for static analysis options
 include(cmake/StaticAnalyzers.cmake)
 
-include_directories(${CMAKE_SOURCE_DIR})
-
-add_subdirectory(submodules)
+add_subdirectory(submodules EXCLUDE_FROM_ALL SYSTEM)
 add_subdirectory(src)
 add_subdirectory(tests)

--- a/src/FCFileInfo.cpp
+++ b/src/FCFileInfo.cpp
@@ -11,8 +11,8 @@
  */
 
 #include <tuple>
-#include "src/FCFileInfoHelpers.hpp"
-#include "src/FCFileInfo.hpp"
+#include "FCFileInfoHelpers.hpp"
+#include "FCFileInfo.hpp"
 
 
 static auto convertCharToType(const char type) -> FCFileType

--- a/src/FCFileInfoHelpers.cpp
+++ b/src/FCFileInfoHelpers.cpp
@@ -10,9 +10,9 @@
  *
  */
 
-#include "src/FCFileInfoHelpers.hpp"
+#include "FCFileInfoHelpers.hpp"
 
-#include "src/log.hpp"
+#include "log.hpp"
 
 #include <algorithm>
 #include <filesystem>

--- a/src/FCFileInfoHelpers.hpp
+++ b/src/FCFileInfoHelpers.hpp
@@ -16,7 +16,7 @@
 #include <sys/stat.h>  // for stat()
 #include <utility>     // for pair<>
 #include <string>      // for string
-#include "src/FCFileInfo.hpp"
+#include "FCFileInfo.hpp"
 
 namespace FCFileInfoHelpers {
 std::pair<bool, uint64_t> readCrc(const std::string &t_File) noexcept;

--- a/src/FCHelpers.cpp
+++ b/src/FCHelpers.cpp
@@ -10,7 +10,7 @@
  *
  */
 
-#include "src/FCHelpers.hpp"
+#include "FCHelpers.hpp"
 
 #include <fmt/core.h>
 #include <string>

--- a/src/FCMount.cpp
+++ b/src/FCMount.cpp
@@ -10,11 +10,11 @@
  *
  */
 
-#include "src/FCMount.hpp"
+#include "FCMount.hpp"
 
-#include "src/FCFileInfoHelpers.hpp"
-#include "src/FCHelpers.hpp"
-#include "src/log.hpp"
+#include "FCFileInfoHelpers.hpp"
+#include "FCHelpers.hpp"
+#include "log.hpp"
 
 #include <cerrno>
 #include <cstring>

--- a/src/IFCSqliteStorage.hpp
+++ b/src/IFCSqliteStorage.hpp
@@ -15,7 +15,7 @@
 #include <memory>
 #include <vector>
 #include <string>
-#include "src/FCFileInfo.hpp"
+#include "FCFileInfo.hpp"
 
 class IFCSqliteStorage
 {

--- a/src/filcompare.cpp
+++ b/src/filcompare.cpp
@@ -1,7 +1,7 @@
-#include "src/log.hpp"
-#include "src/FCFileInfo.hpp"
-#include "src/sqlite_lib_own_implementation/FCSqliteIO.hpp"
-#include "src/sqlitecpp_lib/FCSqliteCppImpl.hpp"
+#include "log.hpp"
+#include "FCFileInfo.hpp"
+#include "sqlite_lib_own_implementation/FCSqliteIO.hpp"
+#include "sqlitecpp_lib/FCSqliteCppImpl.hpp"
 
 #include <string>
 

--- a/src/sqlite_lib_own_implementation/FCSqliteIO.cpp
+++ b/src/sqlite_lib_own_implementation/FCSqliteIO.cpp
@@ -1,6 +1,6 @@
-#include "src/sqlite_lib_own_implementation/FCSqliteIO.hpp"
+#include "FCSqliteIO.hpp"
 
-#include "src/log.hpp"
+#include "../log.hpp"
 
 #include <fmt/core.h>
 #include <map>

--- a/src/sqlite_lib_own_implementation/FCSqliteIO.hpp
+++ b/src/sqlite_lib_own_implementation/FCSqliteIO.hpp
@@ -16,8 +16,8 @@
 #include <memory>
 #include <vector>
 #include <string>
-#include "src/sqlite_lib_own_implementation/FCSqliteLib.hpp"
-#include "src/IFCSqliteStorage.hpp"
+#include "FCSqliteLib.hpp"
+#include "../IFCSqliteStorage.hpp"
 #include <type_traits>
 class FCSqliteIO : public IFCSqliteStorage
 {

--- a/src/sqlite_lib_own_implementation/FCSqliteLib.hpp
+++ b/src/sqlite_lib_own_implementation/FCSqliteLib.hpp
@@ -13,8 +13,8 @@
  *
  */
 
-#include "src/log.hpp"
-#include "src/sqlite_lib_own_implementation/Handle.hpp"
+#include "../log.hpp"
+#include "Handle.hpp"
 
 #include <sqlite3.h>
 #include <string>

--- a/src/sqlitecpp_lib/FCSqliteCppImpl.cpp
+++ b/src/sqlitecpp_lib/FCSqliteCppImpl.cpp
@@ -10,13 +10,14 @@
  * Contact: sergeyvkarasyov@gmail.com
  *
  */
-#include "src/sqlitecpp_lib/FCSqliteCppImpl.hpp"
+#include "FCSqliteCppImpl.hpp"
 
-#include "src/log.hpp"
-#include "submodules/SQLiteCpp/include/SQLiteCpp/Database.h"
-#include "submodules/SQLiteCpp/include/SQLiteCpp/SQLiteCpp.h"
-#include "submodules/SQLiteCpp/include/SQLiteCpp/Statement.h"
-#include "submodules/SQLiteCpp/include/SQLiteCpp/VariadicBind.h"
+#include "../log.hpp"
+
+#include <SQLiteCpp/Database.h>
+#include <SQLiteCpp/SQLiteCpp.h>
+#include <SQLiteCpp/Statement.h>
+#include <SQLiteCpp/VariadicBind.h>
 
 #include <fmt/core.h>
 #include <tuple>

--- a/src/sqlitecpp_lib/FCSqliteCppImpl.hpp
+++ b/src/sqlitecpp_lib/FCSqliteCppImpl.hpp
@@ -17,7 +17,7 @@
 #include <memory>
 #include <vector>
 #include <string>
-#include "src/IFCSqliteStorage.hpp"
+#include "../IFCSqliteStorage.hpp"
 
 class FCSqliteCppImpl : public IFCSqliteStorage
 {


### PR DESCRIPTION
The ${CMAKE_SOURCE_DIR} was added as an include directory. So, all warnings from this directory (including submodules) were reported during the compilation.

Before:

 > /opt/project/submodules/SQLiteCpp/include/SQLiteCpp/Database.h:210:18: warning: useless cast to type 'const char*' [-Wuseless-cast]
 > ...

After:

> (no warnings from submodules)

refs #22